### PR TITLE
Add support for using is.gd shortener

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Feed2twister is a simple script to post items from RSS/ATOM feeds to [Twister](h
 * [Twister](http://twister.net.co/) (of course)
 * [python-bitcoinrpc](https://pypi.python.org/pypi/python-bitcoinrpc/)
 * [feedparser](https://pypi.python.org/pypi/feedparser/)
+* [gdshortener](https://github.com/torre76/gd_shortener/) (optional)
 
 ### Installing
 

--- a/conf-example.py
+++ b/conf-example.py
@@ -6,6 +6,7 @@ RPC_URL = 'http://MYRPCUSER:MYRPCPASSWORD@127.0.0.1:28332' # change to rpcuser a
 DB_FILENAME = 'items.db' # db is mainly there to keep track of "what not to post again" :) (debugging too, I guess)
 MAX_URL_LENGTH = 100 # this leaves 36 characters and a ... to get to 140. If we don't have that, we skip the item :(
 MAX_NEW_ITEMS_PER_FEED = 3 # we don't want to flood more than that in a single run.
+USE_SHORTENER=True
 FEEDS = [ # Use your own feeds, of course :)
     'https://swatwt.com/favs/rss/en',
     'https://github.com/thedod.atom'


### PR DESCRIPTION
USE_SHORTENER steers toggle of shortening urls. As twister has a hard
limit at the moment of 140 characters, the more room we create for
content the better.
