### PR TITLE
Make the maximum notice length configurable

### DIFF
--- a/conf-example.py
+++ b/conf-example.py
@@ -4,6 +4,7 @@ logging.basicConfig(level=logging.INFO)
 USERNAME = 'MYTWISTERUSERNAME' # e.g 'thedod'
 RPC_URL = 'http://MYRPCUSER:MYRPCPASSWORD@127.0.0.1:28332' # change to rpcuser and rpcpassword from ~/.twister/twister.conf
 DB_FILENAME = 'items.db' # db is mainly there to keep track of "what not to post again" :) (debugging too, I guess)
+MAX_NOTICE_LENGTH = 140 # 140 is the default, but newer twister has autosplit feature, so people may want this.
 MAX_URL_LENGTH = 100 # this leaves 36 characters and a ... to get to 140. If we don't have that, we skip the item :(
 MAX_NEW_ITEMS_PER_FEED = 3 # we don't want to flood more than that in a single run.
 FEEDS = [ # Use your own feeds, of course :)


### PR DESCRIPTION
Although the notice length is 140 chars in twister, it does have an
autosplit option, so some people may want to configure it to have a
higher maximum length and let twister deal with it.
