### PR TITLE
Allow content and title to be use for the message

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Feed2twister is a simple script to post items from RSS/ATOM feeds to [Twister](h
 * [Twister](http://twister.net.co/) (of course)
 * [python-bitcoinrpc](https://pypi.python.org/pypi/python-bitcoinrpc/)
 * [feedparser](https://pypi.python.org/pypi/feedparser/)
+* [beautifulsoup](https://pypi.python.org/pypi/beautifulsoup4/)
 * [gdshortener](https://github.com/torre76/gd_shortener/) (optional)
 
 ### Installing

--- a/conf-example.py
+++ b/conf-example.py
@@ -8,6 +8,7 @@ MAX_NOTICE_LENGTH = 140 # 140 is the default, but newer twister has autosplit fe
 MAX_URL_LENGTH = 100 # this leaves 36 characters and a ... to get to 140. If we don't have that, we skip the item :(
 MAX_NEW_ITEMS_PER_FEED = 3 # we don't want to flood more than that in a single run.
 USE_SHORTENER=True
+USE_CONTENT=False  # Set to True to use the content element from the feed instead of the title, this makes for more interesting posts
 FEEDS = [ # Use your own feeds, of course :)
     'https://swatwt.com/favs/rss/en',
     'https://github.com/thedod.atom'


### PR DESCRIPTION
The content element contains the more interesting stuff, but may contain
markup which we remove by using BeautifulSoup get_text() method.

A new configuration variable has been defined to choose between title
and content. This should actually be possible per feed.

The calculation of the length of the message has been changed a bit to
make it more readable.

This pull request depends on the earlier pull requests I made.
